### PR TITLE
ReviewPost와 Hashtag는 M:N 관계 - 해시태그 기능 삭제

### DIFF
--- a/src/main/java/org/swyg/greensumer/domain/ReviewPostEntity.java
+++ b/src/main/java/org/swyg/greensumer/domain/ReviewPostEntity.java
@@ -48,12 +48,7 @@ public class ReviewPostEntity {
     private String content;
 
     // TODO : 이미지 또한 엔티티를 분리하여 관리할 필요가 있음. 이미지 제목, 이미지 경로, 작성자 정보가 필요하기 때문
-    @Setter
-    @Column(name = "hashtag", length = 50)
-    private String hashtag;
-    @Setter
-    @Column(name = "imagePath", length = 500)
-    private String imagePath;
+    @Setter @Column(name = "imagePath", length = 500) private String imagePath;
 
     @Column(name = "registered_at")
     private Timestamp registeredAt;
@@ -74,16 +69,14 @@ public class ReviewPostEntity {
         this.updatedAt = Timestamp.from(Instant.now());
     }
 
-    public ReviewPostEntity() {
-    }
+    public ReviewPostEntity() {}
 
-    public static ReviewPostEntity of(ProductEntity product, UserEntity user, String title, String content, String hashtag, String imagePath) {
+    public static ReviewPostEntity of(ProductEntity product, UserEntity user, String title, String content, String imagePath) {
         ReviewPostEntity reviewPostEntity = new ReviewPostEntity();
         reviewPostEntity.setUser(user);
         reviewPostEntity.setProduct(product);
         reviewPostEntity.setTitle(title);
         reviewPostEntity.setContent(content);
-        reviewPostEntity.setHashtag(hashtag);
         reviewPostEntity.setImagePath(imagePath);
 
         return reviewPostEntity;

--- a/src/main/java/org/swyg/greensumer/dto/ReviewPost.java
+++ b/src/main/java/org/swyg/greensumer/dto/ReviewPost.java
@@ -14,7 +14,6 @@ public class ReviewPost {
     private Integer id;
     private String title;
     private String content;
-    private String hashtag;
     private String imagePath;
     private Product product;
     private User user;
@@ -27,7 +26,6 @@ public class ReviewPost {
                 entity.getId(),
                 entity.getTitle(),
                 entity.getContent(),
-                entity.getHashtag(),
                 entity.getImagePath(),
                 Product.fromEntity(entity.getProduct()),
                 User.fromEntity(entity.getUser()),

--- a/src/main/java/org/swyg/greensumer/dto/ReviewPostWithComment.java
+++ b/src/main/java/org/swyg/greensumer/dto/ReviewPostWithComment.java
@@ -17,7 +17,6 @@ public class ReviewPostWithComment {
     private Integer id;
     private String title;
     private String content;
-    private String hashtag;
     private String imagePath;
     private Product product;
     private User user;
@@ -31,7 +30,6 @@ public class ReviewPostWithComment {
                 entity.getId(),
                 entity.getTitle(),
                 entity.getContent(),
-                entity.getHashtag(),
                 entity.getImagePath(),
                 Product.fromEntity(entity.getProduct()),
                 User.fromEntity(entity.getUser()),

--- a/src/main/java/org/swyg/greensumer/dto/request/ReviewPostCreateRequest.java
+++ b/src/main/java/org/swyg/greensumer/dto/request/ReviewPostCreateRequest.java
@@ -11,10 +11,9 @@ public class ReviewPostCreateRequest {
     private Integer productId;
     private String title;
     private String content;
-    private String hashtag;
     private String imagePath;
 
-    public static ReviewPostCreateRequest of(Integer productId, String title, String content, String hashtag, String imagePath) {
-        return new ReviewPostCreateRequest(productId, title, content, hashtag, imagePath);
+    public static ReviewPostCreateRequest of(Integer productId, String title, String content, String imagePath) {
+        return new ReviewPostCreateRequest(productId, title, content, imagePath);
     }
 }

--- a/src/main/java/org/swyg/greensumer/dto/request/ReviewPostModifyRequest.java
+++ b/src/main/java/org/swyg/greensumer/dto/request/ReviewPostModifyRequest.java
@@ -13,10 +13,9 @@ public class ReviewPostModifyRequest {
     private Integer productId;
     private String title;
     private String content;
-    private String hashtag;
     private String imagePath;
 
-    public static ReviewPostModifyRequest of(Integer productId, String title, String content, String hashtag, String imagePath) {
-        return new ReviewPostModifyRequest(productId, title, content, hashtag, imagePath);
+    public static ReviewPostModifyRequest of(Integer productId, String title, String content, String imagePath) {
+        return new ReviewPostModifyRequest(productId, title, content, imagePath);
     }
 }

--- a/src/main/java/org/swyg/greensumer/dto/response/ReviewPostResponse.java
+++ b/src/main/java/org/swyg/greensumer/dto/response/ReviewPostResponse.java
@@ -16,7 +16,6 @@ public class ReviewPostResponse {
     private ProductResponse product;
     private String title;
     private String content;
-    private String hashtag;
     private String imagePath;
     private Timestamp registeredAt;
     private Timestamp updatedAt;
@@ -29,7 +28,6 @@ public class ReviewPostResponse {
                 ProductResponse.fromProduct(reviewPost.getProduct()),
                 reviewPost.getTitle(),
                 reviewPost.getContent(),
-                reviewPost.getHashtag(),
                 reviewPost.getImagePath(),
                 reviewPost.getRegisteredAt(),
                 reviewPost.getUpdatedAt(),

--- a/src/main/java/org/swyg/greensumer/dto/response/ReviewPostWithCommentResponse.java
+++ b/src/main/java/org/swyg/greensumer/dto/response/ReviewPostWithCommentResponse.java
@@ -17,7 +17,6 @@ public class ReviewPostWithCommentResponse {
     private Integer id;
     private String title;
     private String content;
-    private String hashtag;
     private String imagePath;
     private ProductResponse product;
     private UserResponse user;
@@ -31,7 +30,6 @@ public class ReviewPostWithCommentResponse {
                 postWithComment.getId(),
                 postWithComment.getTitle(),
                 postWithComment.getContent(),
-                postWithComment.getHashtag(),
                 postWithComment.getImagePath(),
                 ProductResponse.fromProduct(postWithComment.getProduct()),
                 UserResponse.fromUser(postWithComment.getUser()),

--- a/src/main/java/org/swyg/greensumer/service/ReviewPostService.java
+++ b/src/main/java/org/swyg/greensumer/service/ReviewPostService.java
@@ -38,7 +38,6 @@ public class ReviewPostService {
                 userEntity,
                 request.getTitle(),
                 request.getContent(),
-                request.getHashtag(),
                 request.getImagePath()
         ));
     }
@@ -62,7 +61,6 @@ public class ReviewPostService {
         reviewPost.setProduct(productEntity);
         reviewPost.setTitle(request.getTitle());
         reviewPost.setContent(request.getContent());
-        reviewPost.setHashtag(request.getHashtag());
         reviewPost.setImagePath(request.getImagePath());
 
         ReviewPostEntity updatedReviewPostEntity = reviewPostEntityRepository.saveAndFlush(reviewPost);

--- a/src/test/java/org/swyg/greensumer/fixture/Fixtures.java
+++ b/src/test/java/org/swyg/greensumer/fixture/Fixtures.java
@@ -9,7 +9,6 @@ import java.sql.Timestamp;
 import java.time.Instant;
 import java.util.LinkedHashSet;
 import java.util.Set;
-import java.util.stream.Collectors;
 
 public class Fixtures {
     private static final String token = "eyJhbGciOiJIUzI1NiJ9.eyJ1c2VybmFtZSI6ImFkbWluIiwiaWF0IjoxNjczMDIwMDYwLCJleHAiOjE2NzU2MTIwNjB9.USuRnODheSfeL65rpXqQOMkVLnOqCtSacrJsLNQXSNg";
@@ -20,7 +19,6 @@ public class Fixtures {
     private static final int modifiedStock = stock + 1;
     private static final String title = "title";
     private static final String content = "content";
-    private static final String hashtag = "hashtag";
     private static final String image = "image";
     private static final String username = "username";
     private static final String password = "password";
@@ -39,7 +37,7 @@ public class Fixtures {
     private static final UserRole sellerRole = UserRole.SELLER;
 
     public static ReviewPost getReviewPost() {
-        return new ReviewPost(id, title, content, hashtag, image, getProduct(), getUser(), getNow(), null, null);
+        return new ReviewPost(id, title, content, image, getProduct(), getUser(), getNow(), null, null);
     }
 
     public static Product getProduct() {
@@ -87,7 +85,7 @@ public class Fixtures {
     }
 
     public static ReviewPostWithComment getReviewPostWithComment() {
-        return new ReviewPostWithComment(id, title, content, hashtag, image, getProduct(), getUser(), Set.of(getReviewComment()), getNow(), null, null);
+        return new ReviewPostWithComment(id, title, content, image, getProduct(), getUser(), Set.of(getReviewComment()), getNow(), null, null);
     }
 
     public static String getToken() {
@@ -173,7 +171,6 @@ public class Fixtures {
         reviewPost.setProduct(getProductEntity());
         reviewPost.setTitle(title);
         reviewPost.setContent(content);
-        reviewPost.setHashtag(hashtag);
         reviewPost.setImagePath(image);
         return reviewPost;
     }

--- a/src/test/java/org/swyg/greensumer/fixture/RequestFixture.java
+++ b/src/test/java/org/swyg/greensumer/fixture/RequestFixture.java
@@ -12,7 +12,6 @@ public class RequestFixture {
     private static final String nickname = "nickname";
     private static final String title = "title";
     private static final String content = "content";
-    private static final String hashtag = "hashtag";
     private static final String image = "image";
     private static final String comment = "comment";
     private static final String name = "name";
@@ -31,11 +30,11 @@ public class RequestFixture {
     private static final int modifiedStock = stock + 1;
 
     public static ReviewPostCreateRequest getReviewPostCreateRequest() {
-        return ReviewPostCreateRequest.of(productId, title, content, hashtag, image);
+        return ReviewPostCreateRequest.of(productId, title, content, image);
     }
 
     public static ReviewPostModifyRequest getReviewPostModifyRequest() {
-        return ReviewPostModifyRequest.of(productId, title, content, hashtag, image);
+        return ReviewPostModifyRequest.of(productId, title, content, image);
     }
 
     public static ReviewCommentCreateRequest getReviewCommentCreateRequest() {

--- a/src/test/java/org/swyg/greensumer/fixture/ResponseFixture.java
+++ b/src/test/java/org/swyg/greensumer/fixture/ResponseFixture.java
@@ -11,12 +11,12 @@ import java.time.Instant;
 import java.util.Set;
 
 public class ResponseFixture {
+
     private ReviewPostWithCommentResponse createReviewPostWithCommentsResponse() {
         return new ReviewPostWithCommentResponse(
                 1,
                 "title",
                 "content",
-                "hashtag",
                 "imagePath",
                 createProductResponse(),
                 createUserResponse(),

--- a/src/test/java/org/swyg/greensumer/service/VerificationServiceTest.java
+++ b/src/test/java/org/swyg/greensumer/service/VerificationServiceTest.java
@@ -53,15 +53,15 @@ class VerificationServiceTest {
         // Given
         VerificationEntity verification = getVerificationEntity();
         String email = verification.getSubject();
-        given(verificationEntityRepository.findBySubject(email)).willReturn(Optional.of(getVerificationEntity()));
-        given(verificationEntityRepository.saveAndFlush(verification)).willReturn(verification);
+        given(verificationEntityRepository.findBySubject(any())).willReturn(Optional.of(getVerificationEntity()));
+        given(verificationEntityRepository.saveAndFlush(any())).willReturn(verification);
 
         // When
         verificationService.checkMail(email, verification.getCode());
 
         //Then
-        verify(verificationEntityRepository, times(1)).findBySubject(email);
-        verify(verificationEntityRepository, times(1)).saveAndFlush(verification);
+        verify(verificationEntityRepository, times(1)).findBySubject(any());
+        verify(verificationEntityRepository, times(1)).saveAndFlush(any());
     }
 
     @DisplayName("메일 인증 확인 - 인증요청을 하지 않은 경우")


### PR DESCRIPTION
서비스에 해시태그 기능을 삭제하기로 결정되어 해시태그 맵핑을 필요하지 않게 되었다.
필드를 삭제하고 테스트 코드를 실행하여 안전성을 확인함.

This closes [#39](https://github.com/SWYG-GreenSumer/GreenSumer_Back/issues/39)