### PR TITLE
ReveiwPost와 Image는 1:N 관계

### DIFF
--- a/src/main/java/org/swyg/greensumer/config/AuthenticationConfig.java
+++ b/src/main/java/org/swyg/greensumer/config/AuthenticationConfig.java
@@ -29,7 +29,7 @@ public class AuthenticationConfig extends WebSecurityConfigurerAdapter {
         web.ignoring()
                 .regexMatchers("^(?!/api/).*")
                 .antMatchers(HttpMethod.POST, "/api/*/users/sign-up", "/api/*/users/login", "/api/*/users/mail", "/api/*/stores")
-                .antMatchers(HttpMethod.GET, "/api/*/users/existUsername", "/api/v1/posts")
+                .antMatchers(HttpMethod.GET, "/api/*/users/existUsername", "/api/v1/posts", "/api/v1/image/*")
                 .antMatchers(HttpMethod.PUT, "/api/*/users/find/password", "/api/*/users/mail", "/api/*/users/find/username")
         ;
     }

--- a/src/main/java/org/swyg/greensumer/controller/ImageController.java
+++ b/src/main/java/org/swyg/greensumer/controller/ImageController.java
@@ -1,0 +1,58 @@
+package org.swyg.greensumer.controller;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.tomcat.util.http.fileupload.IOUtils;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
+import org.swyg.greensumer.dto.Image;
+import org.swyg.greensumer.dto.request.ImageCreateRequest;
+import org.swyg.greensumer.dto.request.ImagesCreateRequest;
+import org.swyg.greensumer.dto.response.ImageCreateResponse;
+import org.swyg.greensumer.dto.response.ImageSearchResponse;
+import org.swyg.greensumer.dto.response.Response;
+import org.swyg.greensumer.service.ImageService;
+
+import javax.annotation.Resource;
+import java.io.IOException;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Slf4j
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1")
+public class ImageController {
+
+    private final ImageService imageService;
+
+    @PostMapping(value = "/image")
+    public Response<ImageCreateResponse> saveImage(@ModelAttribute ImageCreateRequest request, Authentication authentication) throws IOException {
+
+        Image image = imageService.saveImage(request.getImage(), request.getType(), authentication.getName());
+
+        return Response.success(ImageCreateResponse.fromImage(image));
+    }
+
+    @PostMapping(value = "/images")
+    public Response<List<ImageCreateResponse>> saveImages(@ModelAttribute ImagesCreateRequest request, Authentication authentication) throws IOException {
+        List<Image> images = imageService.saveImages(request, authentication.getName());
+
+        return Response.success(images.stream().map(ImageCreateResponse::fromImage).collect(Collectors.toList()));
+    }
+
+    @GetMapping(value = "/image/{imageId}")
+    public ResponseEntity<?> searchImage(@PathVariable Integer imageId) throws IOException {
+        Image image = imageService.searchImage(imageId);
+        return ResponseEntity.status(HttpStatus.OK)
+                .contentType(MediaType.valueOf("image/png"))
+                .body(image.getImageData());
+    }
+
+
+}

--- a/src/main/java/org/swyg/greensumer/domain/ImageEntity.java
+++ b/src/main/java/org/swyg/greensumer/domain/ImageEntity.java
@@ -1,0 +1,64 @@
+package org.swyg.greensumer.domain;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.hibernate.annotations.SQLDelete;
+import org.swyg.greensumer.domain.UserEntity;
+import org.swyg.greensumer.domain.constant.ImageType;
+
+import javax.persistence.*;
+import java.sql.Timestamp;
+import java.time.Instant;
+import java.util.Objects;
+
+@Setter
+@Getter
+@Table(name = "\"image\"")
+@SQLDelete(sql = "UPDATE \"image\" SET deleted_at = NOW() where id=?")
+@Entity
+public class ImageEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Integer id;
+
+    private ImageType imageType;
+
+    @OneToOne @JoinColumn(name = "user_id")
+    private UserEntity userEntity;  // 업로드 한 유저
+
+    private @Column(columnDefinition = "TEXT") String filename;
+    private @Column(name = "imagedata", length = 1000) byte[] imageData;
+
+    @Column(name = "registered_at") private Timestamp registeredAt;
+    @Column(name = "updated_at") private Timestamp updatedAt;
+    @Column(name = "deleted_at") private Timestamp deletedAt;
+
+    @PrePersist void registeredAt() { this.registeredAt = Timestamp.from(Instant.now()); }
+    @PreUpdate  void updatedAt() { this.updatedAt = Timestamp.from(Instant.now());}
+
+    public ImageEntity() {}
+
+    private ImageEntity(ImageType imageType, UserEntity userEntity, String filename, byte[] imageData) {
+        this.imageType = imageType;
+        this.userEntity = userEntity;
+        this.filename = filename;
+        this.imageData = imageData;
+    }
+
+    public static ImageEntity of(ImageType imageType, UserEntity userEntity, String filename, byte[] imageData) {
+        return new ImageEntity(imageType, userEntity, filename, imageData);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof ImageEntity that)) return false;
+        return this.getId() != null && this.getId().equals(that.id);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(this.getId());
+    }
+}

--- a/src/main/java/org/swyg/greensumer/domain/ReviewPostEntity.java
+++ b/src/main/java/org/swyg/greensumer/domain/ReviewPostEntity.java
@@ -10,9 +10,7 @@ import org.hibernate.annotations.Where;
 import javax.persistence.*;
 import java.sql.Timestamp;
 import java.time.Instant;
-import java.util.LinkedHashSet;
-import java.util.Objects;
-import java.util.Set;
+import java.util.*;
 
 @Getter
 @Entity
@@ -40,15 +38,14 @@ public class ReviewPostEntity {
     @OneToMany(mappedBy = "reviewPost", cascade = CascadeType.ALL)
     private final Set<ReviewCommentEntity> comments = new LinkedHashSet<>();
 
-    @Setter
-    @Column(name = "title", length = 50)
-    private String title;
-    @Setter
-    @Column(name = "content", columnDefinition = "TEXT")
-    private String content;
+    @Setter @Column(name = "title", length = 50) private String title;
+    @Setter @Column(name = "content", columnDefinition = "TEXT")  private String content;
 
     // TODO : 이미지 또한 엔티티를 분리하여 관리할 필요가 있음. 이미지 제목, 이미지 경로, 작성자 정보가 필요하기 때문
     @Setter @Column(name = "imagePath", length = 500) private String imagePath;
+
+    @ToString.Exclude @OrderBy("registeredAt ASC") @OneToMany(cascade = {CascadeType.ALL})
+    private final Set<ImageEntity> images = new LinkedHashSet<>();
 
     @Column(name = "registered_at")
     private Timestamp registeredAt;
@@ -59,28 +56,27 @@ public class ReviewPostEntity {
     @Column(name = "deleted_at")
     private Timestamp deletedAt;
 
-    @PrePersist
-    void registeredAt() {
-        this.registeredAt = Timestamp.from(Instant.now());
-    }
-
-    @PreUpdate
-    void updatedAt() {
-        this.updatedAt = Timestamp.from(Instant.now());
-    }
+    @PrePersist void registeredAt() { this.registeredAt = Timestamp.from(Instant.now()); }
+    @PreUpdate void updatedAt() { this.updatedAt = Timestamp.from(Instant.now()); }
 
     public ReviewPostEntity() {}
 
-    public static ReviewPostEntity of(ProductEntity product, UserEntity user, String title, String content, String imagePath) {
-        ReviewPostEntity reviewPostEntity = new ReviewPostEntity();
-        reviewPostEntity.setUser(user);
-        reviewPostEntity.setProduct(product);
-        reviewPostEntity.setTitle(title);
-        reviewPostEntity.setContent(content);
-        reviewPostEntity.setImagePath(imagePath);
-
-        return reviewPostEntity;
+    private ReviewPostEntity (ProductEntity product, UserEntity user, String title, String content) {
+       this.product = product;
+       this.user = user;
+       this.title = title;
+       this.content = content;
     }
+
+    public static ReviewPostEntity of(ProductEntity product, UserEntity user, String title, String content) {
+        return new ReviewPostEntity(product, user, title, content);
+    }
+
+    public void addImage(ImageEntity image){ this.images.add(image); }
+    public void addImages(Collection<ImageEntity> images){ this.images.addAll(images); }
+    public void deleteImage(ImageEntity image) { this.images.remove(image); }
+    public void deleteImages(Collection<ImageEntity> images) { this.images.retainAll(images); }
+    public void clearImages() { this.images.clear(); }
 
     @Override
     public boolean equals(Object o) {

--- a/src/main/java/org/swyg/greensumer/domain/constant/ImageType.java
+++ b/src/main/java/org/swyg/greensumer/domain/constant/ImageType.java
@@ -1,0 +1,5 @@
+package org.swyg.greensumer.domain.constant;
+
+public enum ImageType {
+    POST, PROFILE, PRODUCT, STORE,
+}

--- a/src/main/java/org/swyg/greensumer/dto/Image.java
+++ b/src/main/java/org/swyg/greensumer/dto/Image.java
@@ -1,0 +1,36 @@
+package org.swyg.greensumer.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.swyg.greensumer.domain.ImageEntity;
+import org.swyg.greensumer.domain.constant.ImageType;
+
+import java.sql.Timestamp;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class Image {
+    private Integer id;
+    private ImageType imageType;
+    private User user;
+    private String filename;
+    private byte[] imageData;
+    private Timestamp registeredAt;
+    private Timestamp updatedAt;
+    private Timestamp deletedAt;
+
+    public static Image fromEntity(ImageEntity entity) {
+        return new Image(
+                entity.getId(),
+                entity.getImageType(),
+                User.fromEntity(entity.getUserEntity()),
+                entity.getFilename(),
+                entity.getImageData(),
+                entity.getRegisteredAt(),
+                entity.getUpdatedAt(),
+                entity.getDeletedAt()
+        );
+    }
+}

--- a/src/main/java/org/swyg/greensumer/dto/request/ImageCreateRequest.java
+++ b/src/main/java/org/swyg/greensumer/dto/request/ImageCreateRequest.java
@@ -1,0 +1,12 @@
+package org.swyg.greensumer.dto.request;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.web.multipart.MultipartFile;
+
+@Getter
+@Setter
+public class ImageCreateRequest {
+    private MultipartFile image;
+    private String type;
+}

--- a/src/main/java/org/swyg/greensumer/dto/request/ImagesCreateRequest.java
+++ b/src/main/java/org/swyg/greensumer/dto/request/ImagesCreateRequest.java
@@ -1,0 +1,14 @@
+package org.swyg.greensumer.dto.request;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.List;
+
+@Getter
+@Setter
+public class ImagesCreateRequest {
+    private List<MultipartFile> images;
+    private String type;
+}

--- a/src/main/java/org/swyg/greensumer/dto/response/ImageCreateResponse.java
+++ b/src/main/java/org/swyg/greensumer/dto/response/ImageCreateResponse.java
@@ -1,0 +1,35 @@
+package org.swyg.greensumer.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.swyg.greensumer.domain.constant.ImageType;
+import org.swyg.greensumer.dto.Image;
+
+import java.sql.Timestamp;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class ImageCreateResponse {
+
+    private Integer id;
+    private ImageType imageType;
+    private String filename;
+    private byte[] imageData;
+    private Timestamp registeredAt;
+    private Timestamp updatedAt;
+    private Timestamp deletedAt;
+
+    public static ImageCreateResponse fromImage(Image image){
+        return new ImageCreateResponse(
+                image.getId(),
+                image.getImageType(),
+                image.getFilename(),
+                image.getImageData(),
+                image.getRegisteredAt(),
+                image.getUpdatedAt(),
+                image.getDeletedAt()
+        );
+    }
+}

--- a/src/main/java/org/swyg/greensumer/dto/response/ImageSearchResponse.java
+++ b/src/main/java/org/swyg/greensumer/dto/response/ImageSearchResponse.java
@@ -1,0 +1,23 @@
+package org.swyg.greensumer.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.swyg.greensumer.dto.Image;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class ImageSearchResponse {
+    private Integer id;
+    private String fileName;
+    private byte[] image;
+
+    public static ImageSearchResponse fromImage(Image image) {
+        return new ImageSearchResponse(
+                image.getId(),
+                image.getFilename(),
+                image.getImageData()
+        );
+    }
+}

--- a/src/main/java/org/swyg/greensumer/exception/ErrorCode.java
+++ b/src/main/java/org/swyg/greensumer/exception/ErrorCode.java
@@ -25,7 +25,9 @@ public enum ErrorCode {
     STORE_NOT_FOUND(HttpStatus.NOT_FOUND, "store is invalid"),
     COMMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "Comment not founded"),
     SAME_AS_PREVIOUS_PASSWORD(HttpStatus.CONFLICT, "Same as Previous password"),
-    ADDRESS_NOT_FOUND(HttpStatus.NOT_FOUND, "Address not founded")
+    ADDRESS_NOT_FOUND(HttpStatus.NOT_FOUND, "Address not founded"),
+    IMAGE_SAVE_FAIL(HttpStatus.CONFLICT, "Image save failed"),
+    IMAGE_NOT_FOUND(HttpStatus.INTERNAL_SERVER_ERROR, "Image not founded")
     ;
 
     private HttpStatus status;

--- a/src/main/java/org/swyg/greensumer/repository/ImageEntityRepository.java
+++ b/src/main/java/org/swyg/greensumer/repository/ImageEntityRepository.java
@@ -1,0 +1,12 @@
+package org.swyg.greensumer.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.swyg.greensumer.domain.ImageEntity;
+import org.swyg.greensumer.domain.UserEntity;
+
+import java.util.List;
+
+public interface ImageEntityRepository extends JpaRepository<ImageEntity, Integer> {
+
+    List<ImageEntity> findAllByUserEntity(UserEntity user);
+}

--- a/src/main/java/org/swyg/greensumer/service/ImageService.java
+++ b/src/main/java/org/swyg/greensumer/service/ImageService.java
@@ -1,0 +1,79 @@
+package org.swyg.greensumer.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
+import org.swyg.greensumer.domain.ImageEntity;
+import org.swyg.greensumer.domain.UserEntity;
+import org.swyg.greensumer.domain.constant.ImageType;
+import org.swyg.greensumer.dto.Image;
+import org.swyg.greensumer.dto.request.ImageCreateRequest;
+import org.swyg.greensumer.dto.request.ImagesCreateRequest;
+import org.swyg.greensumer.exception.ErrorCode;
+import org.swyg.greensumer.exception.GreenSumerBackApplicationException;
+import org.swyg.greensumer.repository.ImageEntityRepository;
+import org.swyg.greensumer.repository.UserEntityRepository;
+import org.swyg.greensumer.utils.ImageUtils;
+
+import java.io.IOException;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@RequiredArgsConstructor
+@Service
+public class ImageService {
+
+    private final ImageEntityRepository imageEntityRepository;
+    private final UserEntityRepository userEntityRepository;
+
+    @Transactional
+    public Image saveImage(MultipartFile image, String type, String username) throws IOException {
+        UserEntity userEntity = userEntityRepository.findByUsername(username).orElseThrow(() -> {
+            throw new GreenSumerBackApplicationException(ErrorCode.USER_NOT_FOUND, String.format("%s not founded", username));
+        });
+
+        ImageEntity imageEntity = imageEntityRepository.save(ImageEntity.of(
+                ImageType.valueOf(type), userEntity, image.getOriginalFilename(), ImageUtils.compressImage(image.getBytes())
+        ));
+
+        if(imageEntity == null){
+            throw new GreenSumerBackApplicationException(ErrorCode.IMAGE_SAVE_FAIL, String.format("%s cant save", image.getOriginalFilename()));
+        }
+
+        return Image.fromEntity(imageEntity);
+    }
+
+    public Image searchImage(Integer imageId) {
+        ImageEntity imageEntity = imageEntityRepository.findById(imageId).orElseThrow(() -> {
+            throw new GreenSumerBackApplicationException(ErrorCode.IMAGE_NOT_FOUND, String.format("%s not founded", imageId));
+        });
+
+        imageEntity.setImageData(ImageUtils.decompressImage(imageEntity.getImageData()));
+
+        return Image.fromEntity(imageEntity);
+    }
+
+    public List<Image> saveImages(ImagesCreateRequest request, String username) {
+        UserEntity userEntity = userEntityRepository.findByUsername(username).orElseThrow(() -> {
+            throw new GreenSumerBackApplicationException(ErrorCode.USER_NOT_FOUND, String.format("%s not founded", username));
+        });
+
+        List<ImageEntity> imageEntities = new LinkedList<>();
+
+        request.getImages().forEach(e -> {
+            try {
+                ImageEntity saved = imageEntityRepository.save(ImageEntity.of(
+                        ImageType.valueOf(request.getType()), userEntity, e.getOriginalFilename(), ImageUtils.compressImage(e.getBytes())
+                ));
+
+                imageEntities.a(saved);
+            } catch (IOException ex) {
+                throw new GreenSumerBackApplicationException(ErrorCode.IMAGE_SAVE_FAIL, String.format("%s cant save", e.getOriginalFilename()));
+            }
+        });
+
+        return imageEntities.stream().map(Image::fromEntity).collect(Collectors.toList());
+    }
+}

--- a/src/main/java/org/swyg/greensumer/service/ReviewPostService.java
+++ b/src/main/java/org/swyg/greensumer/service/ReviewPostService.java
@@ -37,8 +37,7 @@ public class ReviewPostService {
                 productEntity,
                 userEntity,
                 request.getTitle(),
-                request.getContent(),
-                request.getImagePath()
+                request.getContent()
         ));
     }
 

--- a/src/main/java/org/swyg/greensumer/utils/ImageUtils.java
+++ b/src/main/java/org/swyg/greensumer/utils/ImageUtils.java
@@ -1,0 +1,46 @@
+package org.swyg.greensumer.utils;
+
+import org.apache.tomcat.util.http.fileupload.ByteArrayOutputStream;
+
+import java.util.zip.Deflater;
+import java.util.zip.Inflater;
+
+public class ImageUtils {
+
+    public static byte[] compressImage(byte[] data) {
+        Deflater deflater = new Deflater();
+        deflater.setLevel(Deflater.BEST_COMPRESSION);
+        deflater.setInput(data);
+        deflater.finish();
+
+        ByteArrayOutputStream outputStream = new ByteArrayOutputStream(data.length);
+        byte[] tmp = new byte[4 * 1024];
+        while (!deflater.finished()) {
+            int size = deflater.deflate(tmp);
+            outputStream.write(tmp, 0, size);
+        }
+        try {
+            outputStream.close();
+        } catch (Exception ignored) {
+        }
+        return outputStream.toByteArray();
+    }
+
+
+    public static byte[] decompressImage(byte[] data) {
+        Inflater inflater = new Inflater();
+        inflater.setInput(data);
+        ByteArrayOutputStream outputStream = new ByteArrayOutputStream(data.length);
+        byte[] tmp = new byte[4 * 1024];
+        try {
+            while (!inflater.finished()) {
+                int count = inflater.inflate(tmp);
+                outputStream.write(tmp, 0, count);
+            }
+            outputStream.close();
+        } catch (Exception ignored) {
+        }
+        return outputStream.toByteArray();
+    }
+
+}


### PR DESCRIPTION
이미지 업로드 기능 및 조회 기능을 구현완료하였다.

현재 기술적으로 고민해야할 사항이 있다. 이미지를 DB에서 조회할 경우 비용이 크게 발생한다.
DB IO가 기하급수적으로 증가할 가능성이 있기 때문에 해결할 방안이 필요하다.

This closes [#40](https://github.com/SWYG-GreenSumer/GreenSumer_Back/issues/40)