### PR TITLE
중복된 DB IO 제거

### DIFF
--- a/src/main/java/org/swyg/greensumer/controller/EventController.java
+++ b/src/main/java/org/swyg/greensumer/controller/EventController.java
@@ -29,13 +29,13 @@ public class EventController {
 
     @PostMapping
     public Response<Void> createEvent(@RequestBody EventPostCreateRequest request, Authentication authentication){
-        eventPostService.create(request, request.getStoreId(), request.getProductId(), authentication.getName());
+        eventPostService.create(request, authentication.getName());
         return Response.success();
     }
 
     @PutMapping("/{postId}")
     public Response<EventPostResponse> modifyEvent(@PathVariable Long postId, @RequestBody EventPostModifyRequest request, Authentication authentication) {
-        EventPost eventPost = eventPostService.modify(request, postId, request.getProductId(), authentication.getName());
+        EventPost eventPost = eventPostService.modify(request, postId, authentication.getName());
         return Response.success(EventPostResponse.fromEventPost(eventPost));
     }
 

--- a/src/main/java/org/swyg/greensumer/domain/ProductEntity.java
+++ b/src/main/java/org/swyg/greensumer/domain/ProductEntity.java
@@ -33,6 +33,9 @@ public class ProductEntity extends DateTimeEntity {
     @JsonIgnore @ManyToOne(optional = false, fetch = FetchType.EAGER) @JoinColumn(name = "post_id")
     private ReviewPostEntity reviewPost;
 
+    @JsonIgnore @ManyToOne(optional = false, fetch = FetchType.EAGER) @JoinColumn(name = "event_id")
+    private EventPostEntity eventPost;
+
     @Column(name = "name", length = 50) private String name;
 
     @Column(name = "price") private int price;
@@ -46,6 +49,10 @@ public class ProductEntity extends DateTimeEntity {
 
     public void setReviewPost(ReviewPostEntity reviewPost) {
         this.reviewPost = reviewPost;
+    }
+
+    public void setEventPost(EventPostEntity eventPost) {
+        this.eventPost = eventPost;
     }
 
     public void addStoreProduct(StoreProductEntity storeProductEntity){

--- a/src/main/java/org/swyg/greensumer/domain/ReviewPostEntity.java
+++ b/src/main/java/org/swyg/greensumer/domain/ReviewPostEntity.java
@@ -55,15 +55,6 @@ public class ReviewPostEntity extends PostEntity {
         this.images.addAll(images);
     }
 
-    public void deleteImages(Collection<ImageEntity> images) {
-        images.forEach(e -> e.setReview(this));
-        this.images.retainAll(images);
-    }
-
-    public void clearImages() {
-        this.images.clear();
-    }
-
     public void addViewer(ReviewPostViewerEntity reviewPostViewerEntity) {
         if(this.viewer.contains(reviewPostViewerEntity)){
             return;
@@ -95,5 +86,11 @@ public class ReviewPostEntity extends PostEntity {
         this.title = title;
         this.content = content;
         addProducts(productEntities);
+    }
+
+    public void clear() {
+        this.products.clear();
+        this.images.clear();
+        this.viewer.clear();
     }
 }

--- a/src/main/java/org/swyg/greensumer/dto/EventPost.java
+++ b/src/main/java/org/swyg/greensumer/dto/EventPost.java
@@ -6,6 +6,8 @@ import lombok.NoArgsConstructor;
 import org.swyg.greensumer.domain.EventPostEntity;
 
 import java.sql.Timestamp;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 @Getter
 @NoArgsConstructor
@@ -15,7 +17,7 @@ public class EventPost {
     private String title;
     private String content;
     private Integer views;
-    private Product product;
+    private Set<Product> products;
     private User user;
     private Timestamp registeredAt;
     private Timestamp updatedAt;
@@ -27,7 +29,9 @@ public class EventPost {
                 entity.getTitle(),
                 entity.getContent(),
                 entity.getViews(),
-                Product.fromEntity(entity.getProduct()),
+                entity.getProducts().stream()
+                        .map(Product::fromEntity)
+                        .collect(Collectors.toUnmodifiableSet()),
                 User.fromEntity(entity.getUser()),
                 entity.getRegisteredAt(),
                 entity.getUpdatedAt(),

--- a/src/main/java/org/swyg/greensumer/dto/EventPostWithComment.java
+++ b/src/main/java/org/swyg/greensumer/dto/EventPostWithComment.java
@@ -18,7 +18,7 @@ public class EventPostWithComment {
     private String title;
     private String content;
     private Integer views;
-    private Product product;
+    private Set<Product> products;
     private User user;
     private Set<EventComment> reviewComments;
     private Timestamp registeredAt;
@@ -31,7 +31,9 @@ public class EventPostWithComment {
                 entity.getTitle(),
                 entity.getContent(),
                 entity.getViews(),
-                Product.fromEntity(entity.getProduct()),
+                entity.getProducts().stream()
+                        .map(Product::fromEntity)
+                        .collect(Collectors.toUnmodifiableSet()),
                 User.fromEntity(entity.getUser()),
                 entity.getComments().stream()
                         .map(EventComment::fromEntity)

--- a/src/main/java/org/swyg/greensumer/dto/request/EventPostCreateRequest.java
+++ b/src/main/java/org/swyg/greensumer/dto/request/EventPostCreateRequest.java
@@ -11,12 +11,12 @@ import java.util.List;
 @AllArgsConstructor
 public class EventPostCreateRequest {
     private Long storeId;
-    private Long productId;
     private String title;
     private String content;
+    private List<Long> products;
     private List<Long> images;
 
-    public static EventPostCreateRequest of(Long storeId, Long productId, String title, String content, List<Long> images) {
-        return new EventPostCreateRequest(storeId, productId, title, content, images);
+    public static EventPostCreateRequest of(Long storeId, String title, String content, List<Long> products, List<Long> images) {
+        return new EventPostCreateRequest(storeId, title, content, products, images);
     }
 }

--- a/src/main/java/org/swyg/greensumer/dto/request/EventPostModifyRequest.java
+++ b/src/main/java/org/swyg/greensumer/dto/request/EventPostModifyRequest.java
@@ -10,12 +10,13 @@ import java.util.List;
 @NoArgsConstructor
 @AllArgsConstructor
 public class EventPostModifyRequest {
-    private Long productId;
+    private Long storeId;
     private String title;
     private String content;
+    private List<Long> products;
     private List<Long> images;
 
-    public static EventPostModifyRequest of(Long productId, String title, String content, List<Long> images) {
-        return new EventPostModifyRequest(productId, title, content, images);
+    public static EventPostModifyRequest of(Long storeId, String title, String content, List<Long> products, List<Long> images) {
+        return new EventPostModifyRequest(storeId, title, content, products, images);
     }
 }

--- a/src/main/java/org/swyg/greensumer/dto/response/EventPostResponse.java
+++ b/src/main/java/org/swyg/greensumer/dto/response/EventPostResponse.java
@@ -6,6 +6,8 @@ import lombok.NoArgsConstructor;
 import org.swyg.greensumer.dto.EventPost;
 
 import java.sql.Timestamp;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 @Getter
 @NoArgsConstructor
@@ -13,7 +15,7 @@ import java.sql.Timestamp;
 public class EventPostResponse {
     private Long id;
     private UserResponse user;
-    private ProductResponse product;
+    private Set<ProductResponse> product;
     private String title;
     private String content;
     private Integer views;
@@ -25,7 +27,9 @@ public class EventPostResponse {
         return new EventPostResponse(
                 eventPost.getId(),
                 UserResponse.fromUser(eventPost.getUser()),
-                ProductResponse.fromProduct(eventPost.getProduct()),
+                eventPost.getProducts().stream()
+                        .map(ProductResponse::fromProduct)
+                        .collect(Collectors.toUnmodifiableSet()),
                 eventPost.getTitle(),
                 eventPost.getContent(),
                 eventPost.getViews(),

--- a/src/main/java/org/swyg/greensumer/dto/response/EventPostWithCommentResponse.java
+++ b/src/main/java/org/swyg/greensumer/dto/response/EventPostWithCommentResponse.java
@@ -18,7 +18,7 @@ public class EventPostWithCommentResponse {
     private String title;
     private String content;
     private Integer views;
-    private ProductResponse product;
+    private Set<ProductResponse> products;
     private UserResponse user;
     private Set<EventCommentResponse> reviewComments;
     private Timestamp registeredAt;
@@ -31,7 +31,9 @@ public class EventPostWithCommentResponse {
                 postWithComment.getTitle(),
                 postWithComment.getContent(),
                 postWithComment.getViews(),
-                ProductResponse.fromProduct(postWithComment.getProduct()),
+                postWithComment.getProducts().stream()
+                        .map(ProductResponse::fromProduct)
+                        .collect(Collectors.toUnmodifiableSet()),
                 UserResponse.fromUser(postWithComment.getUser()),
                 postWithComment.getReviewComments().stream()
                         .map(EventCommentResponse::fromEventComment)

--- a/src/main/java/org/swyg/greensumer/repository/ReviewPostEntityRepository.java
+++ b/src/main/java/org/swyg/greensumer/repository/ReviewPostEntityRepository.java
@@ -7,5 +7,5 @@ import org.swyg.greensumer.domain.ReviewPostEntity;
 
 public interface ReviewPostEntityRepository extends JpaRepository<ReviewPostEntity, Long> {
 
-    Page<ReviewPostEntity> findAllByUser_Id(Long userId, Pageable pageable);
+    Page<ReviewPostEntity> findAllByUser_Username(String username, Pageable pageable);
 }

--- a/src/main/java/org/swyg/greensumer/repository/ReviewPostViewerEntityRepository.java
+++ b/src/main/java/org/swyg/greensumer/repository/ReviewPostViewerEntityRepository.java
@@ -8,5 +8,5 @@ import java.util.Optional;
 public interface ReviewPostViewerEntityRepository extends JpaRepository<ReviewPostViewerEntity, Long> {
 
 
-    Optional<ReviewPostViewerEntity> findByReview_IdAndUser_Id(Long reviewPostId, Long userId);
+    Optional<ReviewPostViewerEntity> findByReview_IdAndUser_Username(Long reviewPostId, String username);
 }

--- a/src/main/java/org/swyg/greensumer/service/EventCommentService.java
+++ b/src/main/java/org/swyg/greensumer/service/EventCommentService.java
@@ -35,9 +35,11 @@ public class EventCommentService {
 
     public EventComment modifyComment(Long postId, Long commentId, String content, String username) {
         EventPostEntity eventPostEntity = eventPostService.getEventPostEntityOrException(postId);
-        userEntityRepositoryService.loadUserByUsername(username);
-
         EventCommentEntity eventCommentEntity = getEventCommentEntityOrException(commentId);
+        if(!eventCommentEntity.getUser().getUsername().equals(username)){
+            throw new GreenSumerBackApplicationException(ErrorCode.INVALID_PERMISSION, String.format("%s has no permission", username));
+        }
+
         eventCommentEntity.update(content);
 
         return EventComment.fromEntity(eventCommentEntity);
@@ -45,7 +47,6 @@ public class EventCommentService {
 
     public void deleteComment(Long postId, Long commentId, String username) {
         EventPostEntity eventPostEntity = eventPostService.getEventPostEntityOrException(postId);
-        userEntityRepositoryService.loadUserByUsername(username);
         EventCommentEntity eventCommentEntity = getEventCommentEntityOrException(commentId);
 
         if (!eventCommentEntity.getUser().getUsername().equals(username)) {

--- a/src/main/java/org/swyg/greensumer/service/ReviewCommentService.java
+++ b/src/main/java/org/swyg/greensumer/service/ReviewCommentService.java
@@ -22,7 +22,6 @@ public class ReviewCommentService {
     @Transactional
     public void createComment(Long postId, String content, String username) {
         ReviewPostEntity reviewPostEntity = reviewPostService.getReviewPostEntityOrException(postId);
-
         UserEntity userEntity = userEntityRepositoryService.findByUsernameOrException(username);
 
         reviewCommentRepository.save(ReviewCommentEntity.of(
@@ -35,9 +34,6 @@ public class ReviewCommentService {
     @Transactional
     public ReviewComment modifyComment(Long postId, Long commentId, String content, String username) {
         ReviewPostEntity reviewPostEntity = reviewPostService.getReviewPostEntityOrException(postId);
-
-        userEntityRepositoryService.loadUserByUsername(username);
-
         ReviewCommentEntity reviewCommentEntity = getReviewCommentEntityOrException(commentId);
 
         if (!reviewCommentEntity.getUser().getUsername().equals(username)) {
@@ -51,9 +47,6 @@ public class ReviewCommentService {
 
     public void deleteComment(Long postId, Long commentId, String username) {
         ReviewPostEntity reviewPost = reviewPostService.getReviewPostEntityOrException(postId);
-
-        userEntityRepositoryService.loadUserByUsername(username);
-
         ReviewCommentEntity reviewCommentEntity = getReviewCommentEntityOrException(commentId);
 
         if (!reviewCommentEntity.getUser().getUsername().equals(username)) {

--- a/src/main/java/org/swyg/greensumer/service/ReviewPostService.java
+++ b/src/main/java/org/swyg/greensumer/service/ReviewPostService.java
@@ -56,7 +56,6 @@ public class ReviewPostService {
     public ReviewPost modify(ReviewPostModifyRequest request, Long postId, String username) {
         ReviewPostEntity reviewPostEntity = getReviewPostEntityOrException(postId);
         isPostMine(reviewPostEntity.getUser().getUsername(), username, postId);
-        userEntityRepositoryService.loadUserByUsername(username);
 
         List<ProductEntity> productEntities = storeService.getProductListOnStore(request.getProducts(), request.getStoreId());
 
@@ -72,10 +71,9 @@ public class ReviewPostService {
     @Transactional
     public void delete(Long postId, String username) {
         ReviewPostEntity reviewPostEntity = getReviewPostEntityOrException(postId);
-
-        userEntityRepositoryService.loadUserByUsername(username);
         isPostMine(reviewPostEntity.getUser().getUsername(), username, postId);
 
+        reviewPostEntity.clear();
         reviewPostEntityRepository.delete(reviewPostEntity);
     }
 
@@ -86,8 +84,7 @@ public class ReviewPostService {
 
     @Transactional(readOnly = true)
     public Page<ReviewPost> myList(String username, Pageable pageable) {
-        User user = userEntityRepositoryService.loadUserByUsername(username);
-        return reviewPostEntityRepository.findAllByUser_Id(user.getId(), pageable).map(ReviewPost::fromEntity);
+        return reviewPostEntityRepository.findAllByUser_Username(username, pageable).map(ReviewPost::fromEntity);
     }
 
     @Transactional
@@ -96,7 +93,7 @@ public class ReviewPostService {
 
         ReviewPostEntity reviewPostEntity = getReviewPostEntityOrException(postId);
 
-        ReviewPostViewerEntity reviewPostViewerEntity = reviewPostViewerEntityRepository.findByReview_IdAndUser_Id(postId, userEntity.getId()).orElseGet(
+        ReviewPostViewerEntity reviewPostViewerEntity = reviewPostViewerEntityRepository.findByReview_IdAndUser_Username(postId, username).orElseGet(
                 () -> reviewPostViewerEntityRepository.save(ReviewPostViewerEntity.of(reviewPostEntity, userEntity))
         );
 

--- a/src/main/java/org/swyg/greensumer/service/ReviewPostService.java
+++ b/src/main/java/org/swyg/greensumer/service/ReviewPostService.java
@@ -11,7 +11,6 @@ import org.swyg.greensumer.domain.ReviewPostViewerEntity;
 import org.swyg.greensumer.domain.UserEntity;
 import org.swyg.greensumer.dto.ReviewPost;
 import org.swyg.greensumer.dto.ReviewPostWithComment;
-import org.swyg.greensumer.dto.User;
 import org.swyg.greensumer.dto.request.ReviewPostCreateRequest;
 import org.swyg.greensumer.dto.request.ReviewPostModifyRequest;
 import org.swyg.greensumer.exception.ErrorCode;


### PR DESCRIPTION
1. 이벤트 게시글과 제품 1:N 연관관계로 변경
2. 중복된 회원정보 조회 제거(DB IO)
3. 불필요한 import 제거

This closes [#62](https://github.com/SWYG-GreenSumer/GreenSumer_Back/issues/62)
This closes [#61](https://github.com/SWYG-GreenSumer/GreenSumer_Back/issues/61)