### PR TITLE
인터뷰 저장 로직 문제

### DIFF
--- a/src/main/java/org/swyg/greensumer/repository/InterviewCacheRepository.java
+++ b/src/main/java/org/swyg/greensumer/repository/InterviewCacheRepository.java
@@ -7,7 +7,6 @@ import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.serializer.Jackson2JsonRedisSerializer;
 import org.springframework.stereotype.Repository;
 import org.swyg.greensumer.dto.Interview;
-import org.swyg.greensumer.dto.request.InterviewModifyRequest;
 
 import javax.annotation.PostConstruct;
 import java.util.ArrayList;
@@ -54,16 +53,10 @@ public class InterviewCacheRepository {
             List<Interview> list = new ArrayList<>();
             for (Object value : hashOperations.entries(getKey() + "SELLER").values()) {
                 list.add((Interview) value);
-
-                if(list.size() == 5)
-                    break;
             }
 
             for (Object value : hashOperations.entries(getKey() + "USER").values()) {
                 list.add((Interview) value);
-
-                if(list.size() == 10)
-                    break;
             }
 
             log.info("[InterviewCacheRepository findAll - success]");

--- a/src/main/java/org/swyg/greensumer/repository/InterviewEntityRepository.java
+++ b/src/main/java/org/swyg/greensumer/repository/InterviewEntityRepository.java
@@ -7,5 +7,5 @@ import org.swyg.greensumer.domain.constant.UserRole;
 import java.util.List;
 
 public interface InterviewEntityRepository extends JpaRepository<InterviewEntity, Long> {
-    List<InterviewEntity> findAllByTarget(UserRole role);
+    List<InterviewEntity> findAllByTargetOrderByIdDesc(UserRole role);
 }

--- a/src/main/java/org/swyg/greensumer/service/InterviewService.java
+++ b/src/main/java/org/swyg/greensumer/service/InterviewService.java
@@ -1,8 +1,6 @@
 package org.swyg.greensumer.service;
 
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.swyg.greensumer.domain.InterviewEntity;
 import org.swyg.greensumer.domain.constant.UserRole;
@@ -17,7 +15,6 @@ import org.swyg.greensumer.repository.InterviewEntityRepository;
 import javax.transaction.Transactional;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Objects;
 import java.util.stream.Collectors;
 
 @RequiredArgsConstructor
@@ -46,7 +43,10 @@ public class InterviewService {
         }
 
         interviewEntityRepository.saveAll(list);
-        interviewCacheRepository.setInterviews(list.stream().map(Interview::fromInterviewEntity).collect(Collectors.toList()));
+
+        List<Interview> interviews = getInterviewsFromUser();
+        interviews.addAll(getInterviewsFromSeller());
+        interviewCacheRepository.setInterviews(interviews);
     }
 
     public void deleteInterview(Long interviewId) {
@@ -68,7 +68,7 @@ public class InterviewService {
 
         if (interviews.isEmpty()) {
             interviews.addAll(getInterviewsFromUser());
-            interviews.addAll(getInterviewFromSeller());
+            interviews.addAll(getInterviewsFromSeller());
         }
 
         return interviews;
@@ -76,10 +76,10 @@ public class InterviewService {
 
 
     private List<Interview> getInterviewsFromUser() {
-        return interviewEntityRepository.findAllByTarget(UserRole.USER).stream().map(Interview::fromInterviewEntity).limit(5).collect(Collectors.toList());
+        return interviewEntityRepository.findAllByTargetOrderByIdDesc(UserRole.USER).stream().map(Interview::fromInterviewEntity).limit(5).collect(Collectors.toList());
     }
 
-    private List<Interview> getInterviewFromSeller() {
-        return interviewEntityRepository.findAllByTarget(UserRole.SELLER).stream().map(Interview::fromInterviewEntity).limit(5).collect(Collectors.toList());
+    private List<Interview> getInterviewsFromSeller() {
+        return interviewEntityRepository.findAllByTargetOrderByIdDesc(UserRole.SELLER).stream().map(Interview::fromInterviewEntity).limit(5).collect(Collectors.toList());
     }
 }


### PR DESCRIPTION
**Before**
새로운 데이터를 10개(Seller 5개, User 5개) 입력하였을 경우에 대한 상황을 가지고 캐싱을 했었다.

**After**
추가된 데이터 개수에 관계없이 DB에서 최신 데이터 10개(Seller 5개, User 5개)를 조회하여 해당 데이터를 캐싱하는 방향으로 결정하였다. 

하지만 데이터 추가시마다 캐싱 데이터를 지우고 다시 생성한다는 문제점이 있다. 추후 이점을 보완할 계획을 세워야할 것으로 판단된다. 

This fixed [#75](https://github.com/SWYG-GreenSumer/GreenSumer_Back/issues/75)
