### PR TITLE
#112-게시판과 제품 연관관계 변경

### DIFF
--- a/src/main/java/org/swyg/greensumer/domain/EventPostEntity.java
+++ b/src/main/java/org/swyg/greensumer/domain/EventPostEntity.java
@@ -20,10 +20,8 @@ import java.util.*;
 @Where(clause = "deleted_at is NULL")
 public class EventPostEntity extends PostEntity {
 
-    @OneToMany(mappedBy = "eventPost")
-    private Set<ProductEntity> products = new LinkedHashSet<>();
-
-    @ToString.Exclude @OrderBy("registeredAt DESC")
+    @ToString.Exclude
+    @OrderBy("registeredAt DESC")
     @OneToMany(mappedBy = "eventPost")
     private Set<EventCommentEntity> comments = new LinkedHashSet<>();
 
@@ -34,13 +32,18 @@ public class EventPostEntity extends PostEntity {
     @OneToMany(fetch = FetchType.EAGER, mappedBy = "event", cascade = {CascadeType.ALL}, orphanRemoval = true)
     private Set<EventPostLikeEntity> likes = new LinkedHashSet<>();
 
+    @ToString.Exclude
+    @OneToMany(fetch = FetchType.EAGER, mappedBy = "event", cascade = {CascadeType.ALL}, orphanRemoval = true)
+    private Set<EventPostProductEntity> eventPostProductEntities = new LinkedHashSet<>();
+
     @Enumerated(EnumType.ORDINAL)
     private EventStatus eventStatus;
 
     private LocalDateTime started_at;
     private LocalDateTime ended_at;
 
-    protected EventPostEntity() {}
+    protected EventPostEntity() {
+    }
 
     private EventPostEntity(UserEntity user, String title, String content, LocalDateTime started_at, LocalDateTime ended_at, EventStatus status) {
         this.user = user;
@@ -66,10 +69,10 @@ public class EventPostEntity extends PostEntity {
         this.views++;
     }
 
-    public void addProducts(Collection<ProductEntity> productEntities) {
-        productEntities.forEach(p -> p.setEventPost(this));
-        this.products.clear();
-        this.products.addAll(productEntities);
+    public void setEventPostProductEntities(Collection<EventPostProductEntity> eventPostProductEntities) {
+        eventPostProductEntities.forEach(e -> e.setEvent(this));
+        this.eventPostProductEntities.clear();
+        this.eventPostProductEntities.addAll(eventPostProductEntities);
     }
 
     @Override
@@ -84,19 +87,19 @@ public class EventPostEntity extends PostEntity {
         return Objects.hash(this.getId());
     }
 
-    public void updateEventPost(List<ProductEntity> productEntities, String title, String content, LocalDateTime started_at, LocalDateTime ended_at, EventStatus eventStatus) {
+    public void updateEventPost(List<EventPostProductEntity> eventPostProductEntities, String title, String content, LocalDateTime started_at, LocalDateTime ended_at, EventStatus eventStatus) {
         this.title = title;
         this.content = content;
         this.started_at = started_at;
         this.ended_at = ended_at;
         this.eventStatus = eventStatus;
 
-        addProducts(productEntities);
+        setEventPostProductEntities(eventPostProductEntities);
     }
 
     public void clear() {
         this.images.clear();
-        this.products.clear();
+        this.eventPostProductEntities.clear();
     }
 
     public void addLikes(EventPostLikeEntity eventPostLikeEntity) {

--- a/src/main/java/org/swyg/greensumer/domain/EventPostProductEntity.java
+++ b/src/main/java/org/swyg/greensumer/domain/EventPostProductEntity.java
@@ -1,0 +1,37 @@
+package org.swyg.greensumer.domain;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.SQLDelete;
+import org.hibernate.annotations.Where;
+
+import javax.persistence.*;
+
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Getter
+@Entity
+@Table(name = "event_product")
+@SQLDelete(sql = "UPDATE event_product SET deleted_at = NOW() where id=?")
+@Where(clause = "deleted_at is NULL")
+public class EventPostProductEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne @JoinColumn(name = "event_id") private EventPostEntity event;
+
+    @ManyToOne @JoinColumn(name = "product_id") private ProductEntity product;
+
+    public void setEvent(EventPostEntity event) {
+        this.event = event;
+    }
+
+    public void setProduct(ProductEntity product) {
+        this.product = product;
+    }
+}

--- a/src/main/java/org/swyg/greensumer/domain/ProductEntity.java
+++ b/src/main/java/org/swyg/greensumer/domain/ProductEntity.java
@@ -23,6 +23,7 @@ import java.util.Set;
 @SQLDelete(sql = "UPDATE product SET deleted_at = NOW() where id=?")
 @Where(clause = "deleted_at is NULL")
 public class ProductEntity extends DateTimeEntity {
+
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
@@ -30,11 +31,11 @@ public class ProductEntity extends DateTimeEntity {
     @OneToMany(fetch = FetchType.EAGER, mappedBy = "product")
     private Set<StoreProductEntity> storeProducts = new LinkedHashSet<>();
 
-    @JsonIgnore @ManyToOne(optional = false, fetch = FetchType.EAGER) @JoinColumn(name = "review_id")
-    private ReviewPostEntity reviewPost;
+    @JsonIgnore @OneToMany(fetch = FetchType.EAGER, mappedBy = "product", cascade = CascadeType.MERGE)
+    private Set<ReviewPostProductEntity> reviewPostProducts;
 
-    @JsonIgnore @ManyToOne(optional = false, fetch = FetchType.EAGER) @JoinColumn(name = "event_id")
-    private EventPostEntity eventPost;
+    @JsonIgnore @OneToMany(fetch = FetchType.EAGER, mappedBy = "product", cascade = CascadeType.MERGE)
+    private Set<EventPostProductEntity> eventPostProducts;
 
     @Column(name = "name", length = 50) private String name;
 
@@ -47,21 +48,21 @@ public class ProductEntity extends DateTimeEntity {
     @OneToMany(fetch = FetchType.EAGER, mappedBy = "product", cascade = {CascadeType.ALL}, orphanRemoval = true)
     private Set<ProductImageEntity> images = new LinkedHashSet<>();
 
-    public void setReviewPost(ReviewPostEntity reviewPost) {
-        this.reviewPost = reviewPost;
+    public void setReviewPostProducts(Collection<ReviewPostProductEntity> reviewPostProducts) {
+        reviewPostProducts.forEach(e -> e.setProduct(this));
+        this.reviewPostProducts.clear();
+        this.reviewPostProducts.addAll(reviewPostProducts);
     }
 
-    public void setEventPost(EventPostEntity eventPost) {
-        this.eventPost = eventPost;
+    public void setEventPost(Collection<EventPostProductEntity> eventPostProductEntities) {
+        eventPostProductEntities.forEach(e -> e.setProduct(this));
+        this.eventPostProducts.clear();
+        this.eventPostProducts.addAll(eventPostProductEntities);
     }
 
     public void addStoreProduct(StoreProductEntity storeProductEntity){
         storeProductEntity.setProduct(this);
         this.storeProducts.add(storeProductEntity);
-    }
-
-    public void clearStoreProduct(){
-        this.storeProducts.clear();
     }
 
     public void addImages(Collection<ProductImageEntity> images) {

--- a/src/main/java/org/swyg/greensumer/domain/ReviewPostEntity.java
+++ b/src/main/java/org/swyg/greensumer/domain/ReviewPostEntity.java
@@ -22,21 +22,23 @@ import java.util.Set;
 @Where(clause = "deleted_at is NULL")
 public class ReviewPostEntity extends PostEntity {
 
-    @OneToMany(mappedBy = "reviewPost")
-    private Set<ProductEntity> products = new LinkedHashSet<>();
-
     @ToString.Exclude
     @OrderBy("registeredAt DESC")
     @OneToMany(mappedBy = "reviewPost", cascade = CascadeType.ALL)
     private Set<ReviewCommentEntity> comments = new LinkedHashSet<>();
 
+    @ToString.Exclude
     @OneToMany(mappedBy = "review", orphanRemoval = true, cascade = {CascadeType.ALL})
     private Set<ReviewImageEntity> images = new LinkedHashSet<>();
 
     @ToString.Exclude
     @OneToMany(fetch = FetchType.EAGER, mappedBy = "review", cascade = {CascadeType.ALL}, orphanRemoval = true)
     private Set<ReviewPostLikeEntity> likes = new LinkedHashSet<>();
-    
+
+    @ToString.Exclude
+    @OneToMany(fetch = FetchType.EAGER, mappedBy = "review", cascade = {CascadeType.ALL}, orphanRemoval = true)
+    private Set<ReviewPostProductEntity> postProductsEntities = new LinkedHashSet<>();
+
     private String rating;
 
     public ReviewPostEntity() {
@@ -53,6 +55,12 @@ public class ReviewPostEntity extends PostEntity {
         return new ReviewPostEntity(user, title, content, rating);
     }
 
+    public void setProducts(Collection<ReviewPostProductEntity> products) {
+        postProductsEntities.forEach(e -> e.setReviewPost(this));
+        this.postProductsEntities.clear();
+        this.postProductsEntities.addAll(products);
+    }
+
     public void addImages(Collection<ReviewImageEntity> images) {
         images.forEach(e -> e.setReview(this));
         this.images.clear();
@@ -60,13 +68,7 @@ public class ReviewPostEntity extends PostEntity {
     }
 
     public void addViewer() {
-       this.views++;
-    }
-
-    public void addProducts(Collection<ProductEntity> productEntities) {
-        productEntities.forEach(p -> p.setReviewPost(this));
-        this.products.clear();
-        this.products.addAll(productEntities);
+        this.views++;
     }
 
     public void addLikes(ReviewPostLikeEntity reviewPostLikeEntity) {
@@ -90,15 +92,15 @@ public class ReviewPostEntity extends PostEntity {
         return Objects.hash(this.getId());
     }
 
-    public void updateReviewPost(String title, String content, String rating, Collection<ProductEntity> productEntities) {
+    public void updateReviewPost(String title, String content, String rating, Collection<ReviewPostProductEntity> reviewPostProductsEntities) {
         this.title = title;
         this.content = content;
         this.rating = rating;
-        addProducts(productEntities);
+        this.setProducts(reviewPostProductsEntities);
     }
 
     public void clear() {
-        this.products.clear();
+        this.postProductsEntities.clear();
         this.images.clear();
     }
 }

--- a/src/main/java/org/swyg/greensumer/domain/ReviewPostProductEntity.java
+++ b/src/main/java/org/swyg/greensumer/domain/ReviewPostProductEntity.java
@@ -1,0 +1,37 @@
+package org.swyg.greensumer.domain;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import org.hibernate.annotations.SQLDelete;
+import org.hibernate.annotations.Where;
+
+import javax.persistence.*;
+
+@Builder
+@AllArgsConstructor
+@Getter
+@Entity
+@Table(name = "review_product")
+@SQLDelete(sql = "UPDATE review_product SET deleted_at = NOW() where id=?")
+@Where(clause = "deleted_at is NULL")
+public class ReviewPostProductEntity extends DateTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne @JoinColumn(name = "review_id") private ReviewPostEntity review;
+
+    @ManyToOne @JoinColumn(name = "product_id") private ProductEntity product;
+
+    public ReviewPostProductEntity() {}
+
+    public void setReviewPost(ReviewPostEntity review) {
+        this.review = review;
+    }
+
+    public void setProduct(ProductEntity product) {
+        this.product = product;
+    }
+}

--- a/src/main/java/org/swyg/greensumer/dto/EventPost.java
+++ b/src/main/java/org/swyg/greensumer/dto/EventPost.java
@@ -19,7 +19,7 @@ public class EventPost {
     private String content;
     private Long views;
     private Integer likes;
-    private Set<Product> products;
+    private Set<EventPostWithProduct> products;
     private Set<Image> images;
     private User user;
     private EventStatus eventStatus;
@@ -36,8 +36,8 @@ public class EventPost {
                 entity.getContent(),
                 entity.getViews(),
                 entity.getLikes().size(),
-                entity.getProducts().stream()
-                        .map(Product::fromEntity)
+                entity.getEventPostProductEntities().stream()
+                        .map(EventPostWithProduct::fromEntity)
                         .collect(Collectors.toUnmodifiableSet()),
                 entity.getImages().stream()
                         .map(Image::fromEventImageEntity)

--- a/src/main/java/org/swyg/greensumer/dto/EventPostWithComment.java
+++ b/src/main/java/org/swyg/greensumer/dto/EventPostWithComment.java
@@ -20,7 +20,7 @@ public class EventPostWithComment {
     private String content;
     private Long views;
     private Integer likes;
-    private Set<Product> products;
+    private Set<EventPostWithProduct> products;
     private Set<Image> images;
     private User user;
     private Set<EventComment> reviewComments;
@@ -38,8 +38,8 @@ public class EventPostWithComment {
                 entity.getContent(),
                 entity.getViews(),
                 entity.getLikes().size(),
-                entity.getProducts().stream()
-                        .map(Product::fromEntity)
+                entity.getEventPostProductEntities().stream()
+                        .map(EventPostWithProduct::fromEntity)
                         .collect(Collectors.toUnmodifiableSet()),
                 entity.getImages().stream()
                         .map(Image::fromEventImageEntity)

--- a/src/main/java/org/swyg/greensumer/dto/EventPostWithProduct.java
+++ b/src/main/java/org/swyg/greensumer/dto/EventPostWithProduct.java
@@ -1,0 +1,25 @@
+package org.swyg.greensumer.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.swyg.greensumer.domain.EventPostProductEntity;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class EventPostWithProduct {
+    private Long id;
+    private EventPost eventPost;
+    private Product product;
+
+    public static EventPostWithProduct fromEntity(EventPostProductEntity entity) {
+        return EventPostWithProduct.builder()
+                .id(entity.getId())
+                .eventPost(EventPost.fromEntity(entity.getEvent()))
+                .product(Product.fromEntity(entity.getProduct()))
+                .build();
+    }
+}

--- a/src/main/java/org/swyg/greensumer/dto/ReviewPost.java
+++ b/src/main/java/org/swyg/greensumer/dto/ReviewPost.java
@@ -20,7 +20,7 @@ public class ReviewPost {
     private Integer likes;
     private String scope;
     private Set<ReviewComment> comments;
-    private Set<Product> products;
+    private Set<ReviewPostWithProduct> products;
     private Set<Image> images;
     private User user;
     private LocalDateTime registeredAt;
@@ -38,8 +38,8 @@ public class ReviewPost {
                 entity.getComments().stream()
                         .map(ReviewComment::fromEntity)
                         .collect(Collectors.toUnmodifiableSet()),
-                entity.getProducts().stream()
-                        .map(Product::fromEntity)
+                entity.getPostProductsEntities().stream()
+                        .map(ReviewPostWithProduct::fromEntity)
                         .collect(Collectors.toUnmodifiableSet()),
                 entity.getImages().stream()
                         .map(Image::fromReviewImageEntity)

--- a/src/main/java/org/swyg/greensumer/dto/ReviewPostWithComment.java
+++ b/src/main/java/org/swyg/greensumer/dto/ReviewPostWithComment.java
@@ -19,7 +19,7 @@ public class ReviewPostWithComment {
     private String content;
     private String rating;
     private Long views;
-    private Set<Product> products;
+    private Set<ReviewPostWithProduct> products;
     private Set<Image> images;
     private User user;
     private Set<ReviewComment> reviewComments;
@@ -34,8 +34,8 @@ public class ReviewPostWithComment {
                 entity.getContent(),
                 entity.getRating(),
                 entity.getViews(),
-                entity.getProducts().stream()
-                        .map(Product::fromEntity)
+                entity.getPostProductsEntities().stream()
+                        .map(ReviewPostWithProduct::fromEntity)
                         .collect(Collectors.toUnmodifiableSet()),
                 entity.getImages().stream()
                         .map(Image::fromReviewImageEntity)

--- a/src/main/java/org/swyg/greensumer/dto/ReviewPostWithProduct.java
+++ b/src/main/java/org/swyg/greensumer/dto/ReviewPostWithProduct.java
@@ -1,0 +1,25 @@
+package org.swyg.greensumer.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.swyg.greensumer.domain.ReviewPostProductEntity;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class ReviewPostWithProduct {
+    private Long id;
+    private ReviewPost reviewPost;
+    private Product product;
+
+    public static ReviewPostWithProduct fromEntity(ReviewPostProductEntity entity) {
+        return ReviewPostWithProduct.builder()
+                .id(entity.getId())
+                .reviewPost(ReviewPost.fromEntity(entity.getReview()))
+                .product(Product.fromEntity(entity.getProduct()))
+                .build();
+    }
+}

--- a/src/main/java/org/swyg/greensumer/dto/response/EventPostResponse.java
+++ b/src/main/java/org/swyg/greensumer/dto/response/EventPostResponse.java
@@ -16,7 +16,7 @@ import java.util.stream.Collectors;
 public class EventPostResponse {
     private Long id;
     private UserResponse user;
-    private Set<ProductResponse> product;
+    private Set<EventPostWithProductResponse> product;
     private Set<ImageResponse> images;
     private String title;
     private String content;
@@ -34,7 +34,7 @@ public class EventPostResponse {
                 eventPost.getId(),
                 UserResponse.fromUser(eventPost.getUser()),
                 eventPost.getProducts().stream()
-                        .map(ProductResponse::fromProduct)
+                        .map(EventPostWithProductResponse::fromEventPostWithProduct)
                         .collect(Collectors.toUnmodifiableSet()),
                 eventPost.getImages().stream()
                         .map(ImageResponse::fromImage)

--- a/src/main/java/org/swyg/greensumer/dto/response/EventPostWithCommentResponse.java
+++ b/src/main/java/org/swyg/greensumer/dto/response/EventPostWithCommentResponse.java
@@ -20,7 +20,7 @@ public class EventPostWithCommentResponse {
     private String content;
     private Long views;
     private Integer likes;
-    private Set<ProductResponse> products;
+    private Set<EventPostWithProductResponse> products;
     private Set<ImageResponse> images;
     private UserResponse user;
     private Set<EventCommentResponse> reviewComments;
@@ -39,7 +39,7 @@ public class EventPostWithCommentResponse {
                 postWithComment.getViews(),
                 postWithComment.getLikes(),
                 postWithComment.getProducts().stream()
-                        .map(ProductResponse::fromProduct)
+                        .map(EventPostWithProductResponse::fromEventPostWithProduct)
                         .collect(Collectors.toUnmodifiableSet()),
                 postWithComment.getImages().stream()
                         .map(ImageResponse::fromImage)

--- a/src/main/java/org/swyg/greensumer/dto/response/EventPostWithProductResponse.java
+++ b/src/main/java/org/swyg/greensumer/dto/response/EventPostWithProductResponse.java
@@ -1,0 +1,24 @@
+package org.swyg.greensumer.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.swyg.greensumer.dto.EventPostWithProduct;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class EventPostWithProductResponse {
+    private Long id;
+    private EventPostResponse eventPost;
+    private ProductResponse product;
+
+    public static EventPostWithProductResponse fromEventPostWithProduct(EventPostWithProduct eventPostWithProduct) {
+        return EventPostWithProductResponse.builder()
+                .eventPost(EventPostResponse.fromEventPost(eventPostWithProduct.getEventPost()))
+                .product(ProductResponse.fromProduct(eventPostWithProduct.getProduct()))
+                .build();
+    }
+}

--- a/src/main/java/org/swyg/greensumer/dto/response/ReviewPostResponse.java
+++ b/src/main/java/org/swyg/greensumer/dto/response/ReviewPostResponse.java
@@ -15,7 +15,7 @@ import java.util.stream.Collectors;
 public class ReviewPostResponse {
     private Long id;
     private UserResponse user;
-    private Set<ProductResponse> products;
+    private Set<ReviewPostWithProductResponse> products;
     private Set<ImageResponse> images;
     private String title;
     private String content;
@@ -30,7 +30,7 @@ public class ReviewPostResponse {
                 reviewPost.getId(),
                 UserResponse.fromUser(reviewPost.getUser()),
                 reviewPost.getProducts().stream()
-                        .map(ProductResponse::fromProduct)
+                        .map(ReviewPostWithProductResponse::fromReviewPostWithProduct)
                         .collect(Collectors.toUnmodifiableSet()),
                 reviewPost.getImages().stream()
                         .map(ImageResponse::fromImage)

--- a/src/main/java/org/swyg/greensumer/dto/response/ReviewPostWithCommentResponse.java
+++ b/src/main/java/org/swyg/greensumer/dto/response/ReviewPostWithCommentResponse.java
@@ -19,7 +19,7 @@ public class ReviewPostWithCommentResponse {
     private String content;
     private String rating;
     private Long views;
-    private Set<ProductResponse> products;
+    private Set<ReviewPostWithProductResponse> products;
     private Set<ImageResponse> images;
     private UserResponse user;
     private Set<ReviewCommentResponse> reviewComments;
@@ -35,7 +35,7 @@ public class ReviewPostWithCommentResponse {
                 postWithComment.getRating(),
                 postWithComment.getViews(),
                 postWithComment.getProducts().stream()
-                        .map(ProductResponse::fromProduct)
+                        .map(ReviewPostWithProductResponse::fromReviewPostWithProduct)
                         .collect(Collectors.toUnmodifiableSet()),
                 postWithComment.getImages().stream()
                         .map(ImageResponse::fromImage)

--- a/src/main/java/org/swyg/greensumer/dto/response/ReviewPostWithProductResponse.java
+++ b/src/main/java/org/swyg/greensumer/dto/response/ReviewPostWithProductResponse.java
@@ -1,0 +1,24 @@
+package org.swyg.greensumer.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.swyg.greensumer.dto.ReviewPostWithProduct;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class ReviewPostWithProductResponse {
+    private Long id;
+    private ReviewPostResponse reviewPost;
+    private ProductResponse product;
+
+    public static ReviewPostWithProductResponse fromReviewPostWithProduct(ReviewPostWithProduct reviewPostWithProduct) {
+        return ReviewPostWithProductResponse.builder()
+                .reviewPost(ReviewPostResponse.fromReviewPost(reviewPostWithProduct.getReviewPost()))
+                .product(ProductResponse.fromProduct(reviewPostWithProduct.getProduct()))
+                .build();
+    }
+}

--- a/src/main/java/org/swyg/greensumer/repository/event/EventPostProductEntityRepository.java
+++ b/src/main/java/org/swyg/greensumer/repository/event/EventPostProductEntityRepository.java
@@ -1,0 +1,7 @@
+package org.swyg.greensumer.repository.event;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.swyg.greensumer.domain.EventPostProductEntity;
+
+public interface EventPostProductEntityRepository extends JpaRepository<EventPostProductEntity, Long> {
+}

--- a/src/main/java/org/swyg/greensumer/repository/review/ReviewPostProductEntityRepository.java
+++ b/src/main/java/org/swyg/greensumer/repository/review/ReviewPostProductEntityRepository.java
@@ -1,0 +1,7 @@
+package org.swyg.greensumer.repository.review;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.swyg.greensumer.domain.ReviewPostProductEntity;
+
+public interface ReviewPostProductEntityRepository extends JpaRepository<ReviewPostProductEntity, Long> {
+}

--- a/src/main/java/org/swyg/greensumer/service/ReviewPostService.java
+++ b/src/main/java/org/swyg/greensumer/service/ReviewPostService.java
@@ -15,8 +15,10 @@ import org.swyg.greensumer.exception.ErrorCode;
 import org.swyg.greensumer.exception.GreenSumerBackApplicationException;
 import org.swyg.greensumer.repository.review.ReviewPostEntityRepository;
 import org.swyg.greensumer.repository.review.ReviewPostLikeEntityRepository;
+import org.swyg.greensumer.repository.review.ReviewPostProductEntityRepository;
 import org.swyg.greensumer.repository.review.ViewsCacheRepository;
 
+import java.util.LinkedList;
 import java.util.List;
 import java.util.Objects;
 import java.util.stream.Collectors;
@@ -33,6 +35,7 @@ public class ReviewPostService {
     private final ImageService imageService;
     private final ReviewPostLikeEntityRepository reviewPostLikeEntityRepository;
     private final ViewsCacheRepository viewsCacheRepository;
+    private final ReviewPostProductEntityRepository reviewPostProductEntityRepository;
 
     @Transactional
     public void create(ReviewPostCreateRequest request, String username) {
@@ -46,9 +49,16 @@ public class ReviewPostService {
                 request.getRating()
         ));
 
-        if(productEntities.size() > 0){
-            reviewPostEntity.addProducts(productEntities);
+        List<ReviewPostProductEntity> reviewPostProductEntities = new LinkedList<>();
+
+        for(ProductEntity product : productEntities) {
+            reviewPostProductEntities.add(ReviewPostProductEntity.builder()
+                    .review(reviewPostEntity)
+                    .product(product)
+                    .build());
         }
+
+        reviewPostProductEntityRepository.saveAll(reviewPostProductEntities);
 
         addImages(request.getImages(), reviewPostEntity);
     }
@@ -60,7 +70,16 @@ public class ReviewPostService {
 
         List<ProductEntity> productEntities = storeService.getProductListOnStore(request.getProducts(), request.getStoreId());
 
-        reviewPostEntity.updateReviewPost(request.getTitle(), request.getContent(), request.getRating(), productEntities);
+        List<ReviewPostProductEntity> reviewPostProductEntities = new LinkedList<>();
+
+        for(ProductEntity product : productEntities) {
+            reviewPostProductEntities.add(ReviewPostProductEntity.builder()
+                    .review(reviewPostEntity)
+                    .product(product)
+                    .build());
+        }
+
+        reviewPostEntity.updateReviewPost(request.getTitle(), request.getContent(), request.getRating(), reviewPostProductEntities);
 
         addImages(request.getImages(), reviewPostEntity);
 


### PR DESCRIPTION
1:N에서 M:N으로 변경하는데 이를 효율적으로 관리하기 위해 
중간 테이블을 생성하여 1:N M:1 구조로 구현하였다.

- 리뷰 게시판과 제품 M:N
- 이벤트 게시판과 제품 M:N

This closes [#112](https://github.com/SWYG-GreenSumer/GreenSumer_Back/issues/112)