### PR TITLE
게시글 리스트 조회 무한 루프

### DIFF
--- a/src/main/java/org/swyg/greensumer/dto/EventPost.java
+++ b/src/main/java/org/swyg/greensumer/dto/EventPost.java
@@ -37,7 +37,7 @@ public class EventPost {
                 entity.getViews(),
                 entity.getLikes().size(),
                 entity.getEventPostProductEntities().stream()
-                        .map(EventPostWithProduct::fromEntity)
+                        .map(EventPostWithProduct::getProductFromEntity)
                         .collect(Collectors.toUnmodifiableSet()),
                 entity.getImages().stream()
                         .map(Image::fromEventImageEntity)

--- a/src/main/java/org/swyg/greensumer/dto/EventPostWithComment.java
+++ b/src/main/java/org/swyg/greensumer/dto/EventPostWithComment.java
@@ -39,7 +39,7 @@ public class EventPostWithComment {
                 entity.getViews(),
                 entity.getLikes().size(),
                 entity.getEventPostProductEntities().stream()
-                        .map(EventPostWithProduct::fromEntity)
+                        .map(EventPostWithProduct::getProductFromEntity)
                         .collect(Collectors.toUnmodifiableSet()),
                 entity.getImages().stream()
                         .map(Image::fromEventImageEntity)

--- a/src/main/java/org/swyg/greensumer/dto/EventPostWithProduct.java
+++ b/src/main/java/org/swyg/greensumer/dto/EventPostWithProduct.java
@@ -15,10 +15,8 @@ public class EventPostWithProduct {
     private EventPost eventPost;
     private Product product;
 
-    public static EventPostWithProduct fromEntity(EventPostProductEntity entity) {
+    public static EventPostWithProduct getProductFromEntity(EventPostProductEntity entity) {
         return EventPostWithProduct.builder()
-                .id(entity.getId())
-                .eventPost(EventPost.fromEntity(entity.getEvent()))
                 .product(Product.fromEntity(entity.getProduct()))
                 .build();
     }

--- a/src/main/java/org/swyg/greensumer/dto/ReviewPost.java
+++ b/src/main/java/org/swyg/greensumer/dto/ReviewPost.java
@@ -20,7 +20,7 @@ public class ReviewPost {
     private Integer likes;
     private String scope;
     private Set<ReviewComment> comments;
-    private Set<Product> products;
+    private Set<ReviewPostWithProduct> products;
     private Set<Image> images;
     private User user;
     private LocalDateTime registeredAt;
@@ -39,8 +39,7 @@ public class ReviewPost {
                         .map(ReviewComment::fromEntity)
                         .collect(Collectors.toUnmodifiableSet()),
                 entity.getPostProductsEntities().stream()
-                        .map(ReviewPostWithProduct::fromEntity)
-                        .map(ReviewPostWithProduct::getProduct)
+                        .map(ReviewPostWithProduct::getProductFromEntity)
                         .collect(Collectors.toUnmodifiableSet()),
                 entity.getImages().stream()
                         .map(Image::fromReviewImageEntity)

--- a/src/main/java/org/swyg/greensumer/dto/ReviewPostWithComment.java
+++ b/src/main/java/org/swyg/greensumer/dto/ReviewPostWithComment.java
@@ -35,7 +35,7 @@ public class ReviewPostWithComment {
                 entity.getRating(),
                 entity.getViews(),
                 entity.getPostProductsEntities().stream()
-                        .map(ReviewPostWithProduct::fromEntity)
+                        .map(ReviewPostWithProduct::getProductFromEntity)
                         .collect(Collectors.toUnmodifiableSet()),
                 entity.getImages().stream()
                         .map(Image::fromReviewImageEntity)

--- a/src/main/java/org/swyg/greensumer/dto/ReviewPostWithProduct.java
+++ b/src/main/java/org/swyg/greensumer/dto/ReviewPostWithProduct.java
@@ -15,10 +15,8 @@ public class ReviewPostWithProduct {
     private ReviewPost reviewPost;
     private Product product;
 
-    public static ReviewPostWithProduct fromEntity(ReviewPostProductEntity entity) {
+    public static ReviewPostWithProduct getProductFromEntity(ReviewPostProductEntity entity) {
         return ReviewPostWithProduct.builder()
-                .id(entity.getId())
-                .reviewPost(ReviewPost.fromEntity(entity.getReview()))
                 .product(Product.fromEntity(entity.getProduct()))
                 .build();
     }

--- a/src/main/java/org/swyg/greensumer/dto/response/EventPostWithProductResponse.java
+++ b/src/main/java/org/swyg/greensumer/dto/response/EventPostWithProductResponse.java
@@ -11,13 +11,10 @@ import org.swyg.greensumer.dto.EventPostWithProduct;
 @AllArgsConstructor
 @NoArgsConstructor
 public class EventPostWithProductResponse {
-    private Long id;
-    private EventPostResponse eventPost;
     private ProductResponse product;
 
     public static EventPostWithProductResponse fromEventPostWithProduct(EventPostWithProduct eventPostWithProduct) {
         return EventPostWithProductResponse.builder()
-                .eventPost(EventPostResponse.fromEventPost(eventPostWithProduct.getEventPost()))
                 .product(ProductResponse.fromProduct(eventPostWithProduct.getProduct()))
                 .build();
     }

--- a/src/main/java/org/swyg/greensumer/dto/response/ProductResponse.java
+++ b/src/main/java/org/swyg/greensumer/dto/response/ProductResponse.java
@@ -1,14 +1,17 @@
 package org.swyg.greensumer.dto.response;
 
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.swyg.greensumer.dto.Product;
+import org.swyg.greensumer.dto.ReviewPostWithProduct;
 
 import java.util.Set;
 import java.util.stream.Collectors;
 
 @Getter
+@Builder
 @NoArgsConstructor
 @AllArgsConstructor
 public class ProductResponse {
@@ -31,4 +34,18 @@ public class ProductResponse {
                         .collect(Collectors.toUnmodifiableSet())
         );
     }
+
+    public static ProductResponse fromReviewPostWithProduct(ReviewPostWithProduct product){
+        return ProductResponse.builder()
+                .id(product.getProduct().getId())
+                .name(product.getProduct().getName())
+                .price(product.getProduct().getPrice())
+                .stock(product.getProduct().getStock())
+                .description(product.getProduct().getDescription())
+                .images(product.getProduct().getImages().stream()
+                        .map(ImageResponse::fromImage)
+                        .collect(Collectors.toUnmodifiableSet()))
+                .build();
+    }
+
 }

--- a/src/main/java/org/swyg/greensumer/dto/response/ReviewPostResponse.java
+++ b/src/main/java/org/swyg/greensumer/dto/response/ReviewPostResponse.java
@@ -13,7 +13,7 @@ import java.util.stream.Collectors;
 public class ReviewPostResponse {
     private Long id;
     private String writer;
-    private Set<ProductResponse> products;
+    private Set<ReviewPostWithProductResponse> products;
     private Set<ImageResponse> images;
     private String title;
     private String content;
@@ -33,7 +33,7 @@ public class ReviewPostResponse {
                 .views(reviewPost.getViews())
                 .scope(reviewPost.getScope())
                 .products(reviewPost.getProducts().stream()
-                        .map(ProductResponse::fromProduct)
+                        .map(ReviewPostWithProductResponse::fromReviewPostWithProduct)
                         .collect(Collectors.toUnmodifiableSet()))
                 .images(reviewPost.getImages().stream()
                         .map(ImageResponse::fromImage)


### PR DESCRIPTION
게시글 조회 시 순환 참조 에러가 발생하여 연관관계 클래스를 Dto에서 필요한 데이터만 반환하도록 변경함.

This fixed [#123](https://github.com/SWYG-GreenSumer/GreenSumer_Back/issues/123)